### PR TITLE
support for package references (PackageReference) in project files

### DIFF
--- a/src/Transformer.VisualStudio/scripts/TransformerModule.psm1
+++ b/src/Transformer.VisualStudio/scripts/TransformerModule.psm1
@@ -1,6 +1,4 @@
-﻿$sln_dir = Split-Path $dte.Solution.FullName
-$package_folder = Get-ChildItem (Join-Path $sln_dir "packages") -Filter Transformer.VisualStudio* | select -ExpandProperty Fullname -Last 1
-$transformer_exe = Join-Path $package_folder "tools/transformer.exe"
+﻿$transformer_exe = Join-Path $PSScriptRoot "transformer.exe"
 
 function Switch-Environment {
 	[CmdletBinding()]


### PR DESCRIPTION
Package references, using the PackageReference node, manage NuGet dependencies directly within project files (as opposed to a separate packages.config file). 
[https://docs.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files](url)

When this is used the tools folder location changes to /packages/{package_name}/**{version}**/tools. Furthermore the default packages location moves to the windows Users folder.

Therefore the existing logic for getting the transformer.exe location is not correct for the projects using ProjectReference.

I suggest using the powershell automatic variable $PSScriptRoot to get the path to the running script to locate transformer.exe.

